### PR TITLE
Fixed a bug that caused long DKIM public keys to be truncated

### DIFF
--- a/src/nodemailer-dkim.js
+++ b/src/nodemailer-dkim.js
@@ -77,7 +77,7 @@ function verifyKeys(options, callback) {
         }
 
         var data = {};
-        (result[0] || '').toString().split(/;/).forEach(function(row) {
+        (result[0].join('') || '').toString().split(/;/).forEach(function(row) {
             var key, val;
             row = row.split('=');
             key = (row.shift() || '').toString().trim();

--- a/test/nodemailer-dkim-test.js
+++ b/test/nodemailer-dkim-test.js
@@ -41,7 +41,7 @@ describe('nodemailer-dkim tests', function() {
 
     it('should verify valid keys', function(done) {
         var dns = require('dns');
-        sinon.stub(dns, 'resolveTxt').yields(null, [' p = MHwwDQYJKoZIhvcNAQEBBQADawAwaAJhANCx7ncKUfQ8wBUYmMqq6ky8rBB0NL8knBf3+uA7q/CSxpX6sQ8NdFNtEeEd7gu7BWEM7+PkO1P0M78eZOvVmput8BP9R44ARpgHY4V0qSCdUt4rD32nwfjlGbh8p5ua5wIDAQAB']);
+        sinon.stub(dns, 'resolveTxt').yields(null, [ [' p = MHwwDQYJKoZIhvcNAQEBBQADawAwaAJhANCx7ncKUfQ8wBUYmMqq6ky8rBB0NL8knBf3+uA7q/CSxpX6sQ8NdFNtEeEd7gu7BWEM7+PkO1P0M78eZOvVmput8BP9R44ARpgHY4V0qSCdUt4rD32nwfjlGbh8p5ua5wIDAQAB'] ]);
 
         dkim.verifyKeys({
             domainName: 'node.ee',
@@ -72,7 +72,7 @@ describe('nodemailer-dkim tests', function() {
 
     it('should not verify non matching keys', function(done) {
         var dns = require('dns');
-        sinon.stub(dns, 'resolveTxt').yields(null, ['p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDFDiKg3O4hdG5iehr5MNxMgrJNMUh6hgWekILDZg2I8WGERJTFZpnspUT1wgoVRziVzGB7ORbVOZEPdZy7noNSTpx5hDgHie/8cO1Q9O/IIX6Mx4qfQL21m0d1zZRbCo6wdO/cwXMoqOZN6ijpFsLFBMNanJ7AysIXiu6GeYLxwQIDAQAB']);
+        sinon.stub(dns, 'resolveTxt').yields(null, [ ['p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDFDiKg3O4hdG5iehr5MNxMgrJNMUh6hgWekILDZg2I8WGERJTFZpnspUT1wgoVRziVzGB7ORbVOZEPdZy7noNSTpx5hDgHie/8cO1Q9O/IIX6Mx4qfQL21m0d1zZRbCo6wdO/cwXMoqOZN6ijpFsLFBMNanJ7AysIXiu6GeYLxwQIDAQAB'] ]);
 
         dkim.verifyKeys({
             domainName: 'node.ee',


### PR DESCRIPTION
dns.resolveTxt returns an array of arrays as a result. Only the first item in the array was used, which caused the end part of a long (e.g. 2048 but) public key to be missing. This caused verification error. 